### PR TITLE
controller: single propagation of delta events

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -222,19 +222,13 @@ func (c *Controller) add(obj Object) {
 	defer c.Unlock()
 
 	c.cache.Add(obj)
-	c.propagate([]ResourceEvent{{obj.GetObjectKind().GroupVersionKind().GroupKind(), CreateEvent, nil, obj}})
 }
 
-func (c *Controller) update(oldObj, newObj Object) {
+func (c *Controller) update(_, newObj Object) {
 	c.Lock()
 	defer c.Unlock()
 
-	if oldObj.GetGeneration() == newObj.GetGeneration() {
-		return
-	}
-
 	c.cache.Add(newObj)
-	c.propagate([]ResourceEvent{{newObj.GetObjectKind().GroupVersionKind().GroupKind(), UpdateEvent, oldObj, newObj}})
 }
 
 func (c *Controller) delete(obj Object) {
@@ -242,7 +236,6 @@ func (c *Controller) delete(obj Object) {
 	defer c.Unlock()
 
 	c.cache.Delete(obj)
-	c.propagate([]ResourceEvent{{obj.GetObjectKind().GroupVersionKind().GroupKind(), DeleteEvent, obj, nil}})
 }
 
 func (c *Controller) propagate(resourceEvents []ResourceEvent) {


### PR DESCRIPTION
Fixes the delta reconcilers (based on [`cache.SharedInformer`](https://pkg.go.dev/k8s.io/client-go@v0.30.2/tools/cache#SharedInformer)) so events are propagated only once per event.

Closes #23