### PR TITLE
controller: reconciliation state carryover

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Example:
 ```go
 import (
   "context"
+  "sync"
 
   "k8s.io/apimachinery/pkg/runtime/schema"
   "k8s.io/client-go/dynamic"
@@ -187,7 +188,7 @@ func main() {
 	controller.Start(context.Background())
 }
 
-func reconcile(ctx context.Context, events []ResourceEvent, topology *machinery.Topology) {
+func reconcile(ctx context.Context, events []ResourceEvent, topology *machinery.Topology, state *sync.Map, err error) {
   // TODO
 }
 ```

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -61,7 +61,7 @@ func WithRunnable(name string, builder RunnableBuilder) ControllerOption {
 	}
 }
 
-type ReconcileFunc func(context.Context, []ResourceEvent, *machinery.Topology, error)
+type ReconcileFunc func(context.Context, []ResourceEvent, *machinery.Topology, *sync.Map, error)
 
 func WithReconcile(reconcile ReconcileFunc) ControllerOption {
 	return func(o *ControllerOptions) {
@@ -106,7 +106,7 @@ func NewController(f ...ControllerOption) *Controller {
 		name:      "controller",
 		logger:    logr.Discard(),
 		runnables: map[string]RunnableBuilder{},
-		reconcile: func(context.Context, []ResourceEvent, *machinery.Topology, error) {
+		reconcile: func(context.Context, []ResourceEvent, *machinery.Topology, *sync.Map, error) {
 		},
 	}
 	for _, fn := range f {
@@ -250,7 +250,7 @@ func (c *Controller) propagate(resourceEvents []ResourceEvent) {
 	if err != nil {
 		c.logger.Error(err, "error building topology")
 	}
-	c.reconcile(LoggerIntoContext(context.TODO(), c.logger), resourceEvents, topology, err)
+	c.reconcile(LoggerIntoContext(context.TODO(), c.logger), resourceEvents, topology, &sync.Map{}, err)
 }
 
 func (c *Controller) subscribe() {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -4,6 +4,7 @@ package controller
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -25,7 +26,7 @@ func TestControllerOptions(t *testing.T) {
 		name:      "controller",
 		logger:    logr.Discard(),
 		runnables: map[string]RunnableBuilder{},
-		reconcile: func(context.Context, []ResourceEvent, *machinery.Topology, error) {
+		reconcile: func(context.Context, []ResourceEvent, *machinery.Topology, *sync.Map, error) {
 		},
 	}
 

--- a/controller/subscriber.go
+++ b/controller/subscriber.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"sync"
 
 	"github.com/samber/lo"
 
@@ -16,7 +17,7 @@ type Subscription struct {
 	Events        []ResourceEventMatcher
 }
 
-func (s Subscription) Reconcile(ctx context.Context, resourceEvents []ResourceEvent, topology *machinery.Topology, err error) {
+func (s Subscription) Reconcile(ctx context.Context, resourceEvents []ResourceEvent, topology *machinery.Topology, state *sync.Map, err error) {
 	matchingEvents := lo.Filter(resourceEvents, func(resourceEvent ResourceEvent, _ int) bool {
 		return lo.ContainsBy(s.Events, func(m ResourceEventMatcher) bool {
 			obj := resourceEvent.OldObject
@@ -30,6 +31,6 @@ func (s Subscription) Reconcile(ctx context.Context, resourceEvents []ResourceEv
 		})
 	})
 	if len(matchingEvents) > 0 && s.ReconcileFunc != nil {
-		s.ReconcileFunc(ctx, matchingEvents, topology, err)
+		s.ReconcileFunc(ctx, matchingEvents, topology, state, err)
 	}
 }

--- a/controller/test_helper.go
+++ b/controller/test_helper.go
@@ -4,6 +4,7 @@ package controller
 
 import (
 	"context"
+	"sync"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -51,7 +52,7 @@ func init() {
 			Func: func(_ machinery.Object) []machinery.Object { return []machinery.Object{&RuntimeObject{myObjects[0]}} },
 		}
 	}
-	testReconcileFunc = func(_ context.Context, events []ResourceEvent, topology *machinery.Topology, err error) {
+	testReconcileFunc = func(_ context.Context, events []ResourceEvent, topology *machinery.Topology, _ *sync.Map, err error) {
 		for _, event := range events {
 			testLogger.Info("reconcile",
 				"kind", event.Kind,

--- a/controller/workflow.go
+++ b/controller/workflow.go
@@ -15,10 +15,10 @@ type Workflow struct {
 	Postcondition ReconcileFunc
 }
 
-func (d *Workflow) Run(ctx context.Context, resourceEvents []ResourceEvent, topology *machinery.Topology, err error) {
+func (d *Workflow) Run(ctx context.Context, resourceEvents []ResourceEvent, topology *machinery.Topology, state *sync.Map, err error) {
 	// run precondition reconcile function
 	if d.Precondition != nil {
-		d.Precondition(ctx, resourceEvents, topology, err)
+		d.Precondition(ctx, resourceEvents, topology, state, err)
 	}
 
 	// dispatch the event to concurrent tasks
@@ -28,13 +28,13 @@ func (d *Workflow) Run(ctx context.Context, resourceEvents []ResourceEvent, topo
 	for _, f := range funcs {
 		go func() {
 			defer waitGroup.Done()
-			f(ctx, resourceEvents, topology, err)
+			f(ctx, resourceEvents, topology, state, err)
 		}()
 	}
 	waitGroup.Wait()
 
 	// run precondition reconcile function
 	if d.Postcondition != nil {
-		d.Postcondition(ctx, resourceEvents, topology, err)
+		d.Postcondition(ctx, resourceEvents, topology, state, err)
 	}
 }

--- a/examples/kuadrant/main.go
+++ b/examples/kuadrant/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"sync"
 
 	egv1alpha1 "github.com/envoyproxy/gateway/api/v1alpha1"
 	"github.com/google/go-cmp/cmp"
@@ -201,7 +202,9 @@ func controllerOptionsFor(gatewayProviders []string) []controller.ControllerOpti
 //  3. (gateway deleted) delete SecurityPolicy / (other events) reconcile SecurityPolicies
 //  3. (gateway deleted) delete AuthorizationPolicy / (other events) reconcile AuthorizationPolicies
 func buildReconciler(gatewayProviders []string, client *dynamic.DynamicClient) controller.ReconcileFunc {
-	effectivePolicyReconciler := &reconcilers.EffectivePoliciesReconciler{Client: client}
+	effectivePolicyReconciler := &controller.Workflow{
+		Precondition: reconcilers.ReconcileEffectivePolicies,
+	}
 
 	commonAuthPolicyResourceEventMatchers := []controller.ResourceEventMatcher{
 		{Kind: ptr.To(machinery.GatewayClassGroupKind)},
@@ -215,11 +218,11 @@ func buildReconciler(gatewayProviders []string, client *dynamic.DynamicClient) c
 		switch gatewayProvider {
 		case reconcilers.EnvoyGatewayProviderName:
 			envoyGatewayProvider := &reconcilers.EnvoyGatewayProvider{Client: client}
-			effectivePolicyReconciler.ReconcileFuncs = append(effectivePolicyReconciler.ReconcileFuncs, (&controller.Subscription{
+			effectivePolicyReconciler.Tasks = append(effectivePolicyReconciler.Tasks, (&controller.Subscription{
 				ReconcileFunc: envoyGatewayProvider.ReconcileSecurityPolicies,
 				Events:        append(commonAuthPolicyResourceEventMatchers, controller.ResourceEventMatcher{Kind: ptr.To(reconcilers.EnvoyGatewaySecurityPolicyKind)}),
 			}).Reconcile)
-			effectivePolicyReconciler.ReconcileFuncs = append(effectivePolicyReconciler.ReconcileFuncs, (&controller.Subscription{
+			effectivePolicyReconciler.Tasks = append(effectivePolicyReconciler.Tasks, (&controller.Subscription{
 				ReconcileFunc: envoyGatewayProvider.DeleteSecurityPolicy,
 				Events: []controller.ResourceEventMatcher{
 					{Kind: ptr.To(machinery.GatewayGroupKind), EventType: ptr.To(controller.DeleteEvent)},
@@ -227,11 +230,11 @@ func buildReconciler(gatewayProviders []string, client *dynamic.DynamicClient) c
 			}).Reconcile)
 		case reconcilers.IstioGatewayProviderName:
 			istioGatewayProvider := &reconcilers.IstioGatewayProvider{Client: client}
-			effectivePolicyReconciler.ReconcileFuncs = append(effectivePolicyReconciler.ReconcileFuncs, (&controller.Subscription{
+			effectivePolicyReconciler.Tasks = append(effectivePolicyReconciler.Tasks, (&controller.Subscription{
 				ReconcileFunc: istioGatewayProvider.ReconcileAuthorizationPolicies,
 				Events:        append(commonAuthPolicyResourceEventMatchers, controller.ResourceEventMatcher{Kind: ptr.To(reconcilers.IstioAuthorizationPolicyKind)}),
 			}).Reconcile)
-			effectivePolicyReconciler.ReconcileFuncs = append(effectivePolicyReconciler.ReconcileFuncs, (&controller.Subscription{
+			effectivePolicyReconciler.Tasks = append(effectivePolicyReconciler.Tasks, (&controller.Subscription{
 				ReconcileFunc: istioGatewayProvider.DeleteAuthorizationPolicy,
 				Events: []controller.ResourceEventMatcher{
 					{Kind: ptr.To(machinery.GatewayGroupKind), EventType: ptr.To(controller.DeleteEvent)},
@@ -241,7 +244,7 @@ func buildReconciler(gatewayProviders []string, client *dynamic.DynamicClient) c
 	}
 
 	reconciler := &controller.Workflow{
-		Precondition: func(ctx context.Context, resourceEvents []controller.ResourceEvent, topology *machinery.Topology, err error) {
+		Precondition: func(ctx context.Context, resourceEvents []controller.ResourceEvent, topology *machinery.Topology, _ *sync.Map, err error) {
 			logger := controller.LoggerFromContext(ctx).WithName("event logger")
 			for _, event := range resourceEvents {
 				// log the event
@@ -263,7 +266,7 @@ func buildReconciler(gatewayProviders []string, client *dynamic.DynamicClient) c
 		},
 		Tasks: []controller.ReconcileFunc{
 			(&reconcilers.TopologyFileReconciler{}).Reconcile,
-			effectivePolicyReconciler.Reconcile,
+			effectivePolicyReconciler.Run,
 		},
 	}
 

--- a/examples/kuadrant/reconcilers/istio.go
+++ b/examples/kuadrant/reconcilers/istio.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/samber/lo"
 	istioapiv1 "istio.io/api/security/v1"
@@ -31,11 +32,14 @@ type IstioGatewayProvider struct {
 	Client *dynamic.DynamicClient
 }
 
-func (p *IstioGatewayProvider) ReconcileAuthorizationPolicies(ctx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, err error) {
+func (p *IstioGatewayProvider) ReconcileAuthorizationPolicies(ctx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, state *sync.Map, err error) {
 	logger := controller.LoggerFromContext(ctx).WithName("istio").WithName("authorizationpolicy")
 	ctx = controller.LoggerIntoContext(ctx, logger)
 
-	authPaths := pathsFromContext(ctx, authPathsKey)
+	var authPaths [][]machinery.Targetable
+	if untypedAuthPaths, ok := state.Load(authPathsKey); ok {
+		authPaths = untypedAuthPaths.([][]machinery.Targetable)
+	}
 	targetables := topology.Targetables()
 	gateways := targetables.Items(func(o machinery.Object) bool {
 		_, ok := o.(*machinery.Gateway)
@@ -60,7 +64,7 @@ func (p *IstioGatewayProvider) ReconcileAuthorizationPolicies(ctx context.Contex
 	}
 }
 
-func (p *IstioGatewayProvider) DeleteAuthorizationPolicy(ctx context.Context, resourceEvents []controller.ResourceEvent, topology *machinery.Topology, err error) {
+func (p *IstioGatewayProvider) DeleteAuthorizationPolicy(ctx context.Context, resourceEvents []controller.ResourceEvent, topology *machinery.Topology, _ *sync.Map, err error) {
 	for _, resourceEvent := range resourceEvents {
 		gateway := resourceEvent.OldObject
 		p.deleteAuthorizationPolicy(ctx, topology, gateway.GetNamespace(), gateway.GetName(), nil)

--- a/examples/kuadrant/reconcilers/topology_file_reconciler.go
+++ b/examples/kuadrant/reconcilers/topology_file_reconciler.go
@@ -3,6 +3,7 @@ package reconcilers
 import (
 	"context"
 	"os"
+	"sync"
 
 	"github.com/kuadrant/policy-machinery/controller"
 	"github.com/kuadrant/policy-machinery/machinery"
@@ -12,7 +13,7 @@ const topologyFile = "topology.dot"
 
 type TopologyFileReconciler struct{}
 
-func (r *TopologyFileReconciler) Reconcile(ctx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, err error) {
+func (r *TopologyFileReconciler) Reconcile(ctx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, _ *sync.Map, err error) {
 	logger := controller.LoggerFromContext(ctx).WithName("topology file")
 
 	file, err := os.Create(topologyFile)


### PR DESCRIPTION
Introduces an auxiliary [`sync.Map`](https://pkg.go.dev/sync#Map) struct for carrying reconciliation state over throughout chained reconcile function calls. Provides a better alternative to mutating the context.

Makes it possible to replace the custom `EffectivePoliciesReconciler` from the Kuadrant example with a simple `controller.Workflow`.