### PR TITLE
refactor: allow custom predicates as option

### DIFF
--- a/controller/runnable.go
+++ b/controller/runnable.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/samber/lo"
@@ -198,14 +199,20 @@ type stateReconciler struct {
 	listFunc   ListFunc
 	watchFunc  WatchFunc
 	synced     bool
+	sync.RWMutex
 }
 
 func (r *stateReconciler) Run(_ <-chan struct{}) {
+	r.Lock()
+	defer r.Unlock()
 	r.controller.listAndWatch(r.listFunc, r.watchFunc)
 	r.synced = true
 }
 
 func (r *stateReconciler) HasSynced() bool {
+	r.RLock()
+	defer r.RUnlock()
+
 	return r.synced
 }
 

--- a/examples/kuadrant/main.go
+++ b/examples/kuadrant/main.go
@@ -125,37 +125,37 @@ func main() {
 			&gwapiv1.Gateway{},
 			controller.GatewaysResource,
 			metav1.NamespaceAll,
-			controller.WithPredicates[*gwapiv1.Gateway](&ctrlruntimepredicate.TypedGenerationChangedPredicate[*gwapiv1.Gateway]{})),
+			controller.WithPredicates(&ctrlruntimepredicate.TypedGenerationChangedPredicate[*gwapiv1.Gateway]{})),
 		),
 		controller.WithRunnable("httproute watcher", buildWatcher(
 			&gwapiv1.HTTPRoute{},
 			controller.HTTPRoutesResource,
 			metav1.NamespaceAll,
-			controller.WithPredicates[*gwapiv1.HTTPRoute](&ctrlruntimepredicate.TypedGenerationChangedPredicate[*gwapiv1.HTTPRoute]{})),
+			controller.WithPredicates(&ctrlruntimepredicate.TypedGenerationChangedPredicate[*gwapiv1.HTTPRoute]{})),
 		),
 		controller.WithRunnable("dnspolicy watcher", buildWatcher(
 			&kuadrantv1alpha2.DNSPolicy{},
 			kuadrantv1alpha2.DNSPoliciesResource,
 			metav1.NamespaceAll,
-			controller.WithPredicates[*kuadrantv1alpha2.DNSPolicy](&ctrlruntimepredicate.TypedGenerationChangedPredicate[*kuadrantv1alpha2.DNSPolicy]{})),
+			controller.WithPredicates(&ctrlruntimepredicate.TypedGenerationChangedPredicate[*kuadrantv1alpha2.DNSPolicy]{})),
 		),
 		controller.WithRunnable("tlspolicy watcher", buildWatcher(
 			&kuadrantv1alpha2.TLSPolicy{},
 			kuadrantv1alpha2.TLSPoliciesResource,
 			metav1.NamespaceAll,
-			controller.WithPredicates[*kuadrantv1alpha2.TLSPolicy](&ctrlruntimepredicate.TypedGenerationChangedPredicate[*kuadrantv1alpha2.TLSPolicy]{})),
+			controller.WithPredicates(&ctrlruntimepredicate.TypedGenerationChangedPredicate[*kuadrantv1alpha2.TLSPolicy]{})),
 		),
 		controller.WithRunnable("authpolicy watcher", buildWatcher(
 			&kuadrantv1beta3.AuthPolicy{},
 			kuadrantv1beta3.AuthPoliciesResource,
 			metav1.NamespaceAll,
-			controller.WithPredicates[*kuadrantv1beta3.AuthPolicy](&ctrlruntimepredicate.TypedGenerationChangedPredicate[*kuadrantv1beta3.AuthPolicy]{})),
+			controller.WithPredicates(&ctrlruntimepredicate.TypedGenerationChangedPredicate[*kuadrantv1beta3.AuthPolicy]{})),
 		),
 		controller.WithRunnable("ratelimitpolicy watcher", buildWatcher(
 			&kuadrantv1beta3.RateLimitPolicy{},
 			kuadrantv1beta3.RateLimitPoliciesResource,
 			metav1.NamespaceAll,
-			controller.WithPredicates[*kuadrantv1beta3.RateLimitPolicy](&ctrlruntimepredicate.TypedGenerationChangedPredicate[*kuadrantv1beta3.RateLimitPolicy]{}))),
+			controller.WithPredicates(&ctrlruntimepredicate.TypedGenerationChangedPredicate[*kuadrantv1beta3.RateLimitPolicy]{}))),
 		controller.WithPolicyKinds(
 			kuadrantv1alpha2.DNSPolicyKind,
 			kuadrantv1alpha2.TLSPolicyKind,
@@ -216,7 +216,7 @@ func controllerOptionsFor(gatewayProviders []string) []controller.ControllerOpti
 				&egv1alpha1.SecurityPolicy{},
 				reconcilers.EnvoyGatewaySecurityPoliciesResource,
 				metav1.NamespaceAll,
-				controller.WithPredicates[*egv1alpha1.SecurityPolicy](&ctrlruntimepredicate.TypedGenerationChangedPredicate[*egv1alpha1.SecurityPolicy]{}))),
+				controller.WithPredicates(&ctrlruntimepredicate.TypedGenerationChangedPredicate[*egv1alpha1.SecurityPolicy]{}))),
 			)
 			opts = append(opts, controller.WithObjectKinds(reconcilers.EnvoyGatewaySecurityPolicyKind))
 			opts = append(opts, controller.WithObjectLinks(reconcilers.LinkGatewayToEnvoyGatewaySecurityPolicyFunc))
@@ -225,7 +225,7 @@ func controllerOptionsFor(gatewayProviders []string) []controller.ControllerOpti
 				&istiov1.AuthorizationPolicy{},
 				reconcilers.IstioAuthorizationPoliciesResource,
 				metav1.NamespaceAll,
-				controller.WithPredicates[*istiov1.AuthorizationPolicy](&ctrlruntimepredicate.TypedGenerationChangedPredicate[*istiov1.AuthorizationPolicy]{}))),
+				controller.WithPredicates(&ctrlruntimepredicate.TypedGenerationChangedPredicate[*istiov1.AuthorizationPolicy]{}))),
 			)
 			opts = append(opts, controller.WithObjectKinds(reconcilers.IstioAuthorizationPolicyKind))
 			opts = append(opts, controller.WithObjectLinks(reconcilers.LinkGatewayToIstioAuthorizationPolicyFunc))


### PR DESCRIPTION
# Description
Related to: https://github.com/Kuadrant/kuadrant-operator/pull/885

Allow passing custom predicates as an option to the watch func for the state reconciler.

This removes setting the `&ctrlruntimepredicate.TypedGenerationChangedPredicate[T]{}` predicate by default as this may not be the functionality a user expects, as events revolving around status updates are skipped.

For example, a user might want to receive only status change events for some resources (such as in Kuadrant Operator that watches status change of `Certificate`, `Issuer` & `ClusterIssuer` to calculate the status for `TLSPolicy`)