### PR TITLE
controller: coallescing of sotw cache subscription events

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -3,12 +3,12 @@ package controller
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/samber/lo"
-	"github.com/telepresenceio/watchable"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
@@ -21,6 +21,8 @@ import (
 
 	"github.com/kuadrant/policy-machinery/machinery"
 )
+
+const resourceStoreId = "resources"
 
 type ControllerOptions struct {
 	name               string
@@ -124,7 +126,7 @@ func NewController(f ...ControllerOption) *Controller {
 		logger:    opts.logger,
 		client:    opts.client,
 		manager:   opts.manager,
-		cache:     &watchableCacheStore{},
+		cache:     &CacheStore{},
 		topology:  newGatewayAPITopologyBuilder(opts.policyKinds, opts.objectKinds, opts.objectLinks, opts.allowTopologyLoops),
 		runnables: map[string]Runnable{},
 		reconcile: opts.reconcile,
@@ -146,7 +148,7 @@ type Controller struct {
 	logger     logr.Logger
 	client     *dynamic.DynamicClient
 	manager    ctrlruntime.Manager
-	cache      Cache
+	cache      *CacheStore
 	topology   *gatewayAPITopologyBuilder
 	runnables  map[string]Runnable
 	listFuncs  []ListFunc
@@ -217,7 +219,7 @@ func (c *Controller) Reconcile(ctx context.Context, _ ctrlruntimereconcile.Reque
 			store[string(object.GetUID())] = object
 		}
 	}
-	c.cache.Replace(store)
+	c.cache.Replace(resourceStoreId, store)
 
 	return ctrlruntimereconcile.Result{}, nil
 }
@@ -234,25 +236,25 @@ func (c *Controller) add(obj Object) {
 	c.Lock()
 	defer c.Unlock()
 
-	c.cache.Add(obj)
+	c.cache.Add(resourceStoreId, obj)
 }
 
 func (c *Controller) update(_, newObj Object) {
 	c.Lock()
 	defer c.Unlock()
 
-	c.cache.Add(newObj)
+	c.cache.Add(resourceStoreId, newObj)
 }
 
 func (c *Controller) delete(obj Object) {
 	c.Lock()
 	defer c.Unlock()
 
-	c.cache.Delete(obj)
+	c.cache.Delete(resourceStoreId, obj)
 }
 
 func (c *Controller) propagate(resourceEvents []ResourceEvent) {
-	topology, err := c.topology.Build(c.cache.List())
+	topology, err := c.topology.Build(c.cache.List(resourceStoreId))
 	if err != nil {
 		c.logger.Error(err, "error building topology")
 	}
@@ -262,41 +264,46 @@ func (c *Controller) propagate(resourceEvents []ResourceEvent) {
 }
 
 func (c *Controller) subscribe() {
-	cache, ok := c.cache.(*watchableCacheStore) // should we add Subscribe(ctx) to the Cache interface or remove the interface altogether?
-	if !ok {
-		return
-	}
-	recent := make(Store)
-	subscription := cache.Subscribe(context.TODO())
+	oldObjs := make(Store)
+	subscription := c.cache.Subscribe(context.TODO())
 	go func() {
 		for snapshot := range subscription {
 			c.Lock()
 
-			c.propagate(lo.FlatMap(snapshot.Updates, func(update watchable.Update[string, watchableCacheEntry], _ int) []ResourceEvent {
-				key := update.Key
-				obj := update.Value
+			newObjs := snapshot.State[resourceStoreId]
 
+			events := lo.FilterMap(lo.Keys(newObjs), func(uid string, _ int) (ResourceEvent, bool) {
+				newObj := newObjs[uid]
 				event := ResourceEvent{
-					Kind: obj.GetObjectKind().GroupVersionKind().GroupKind(),
+					Kind:      newObj.GetObjectKind().GroupVersionKind().GroupKind(),
+					NewObject: newObj,
 				}
-
-				if update.Delete {
-					event.EventType = DeleteEvent
-					event.OldObject = obj
-					delete(recent, key)
-				} else {
-					if oldObj, ok := recent[key]; ok {
-						event.EventType = UpdateEvent
-						event.OldObject = oldObj
-					} else {
-						event.EventType = CreateEvent
-					}
-					event.NewObject = obj
-					recent[key] = obj
+				if oldObj, exists := oldObjs[uid]; !exists {
+					event.EventType = CreateEvent
+					oldObjs[uid] = newObj
+					return event, true
+				} else if !reflect.DeepEqual(oldObj, newObj) {
+					event.EventType = UpdateEvent
+					event.OldObject = oldObj
+					oldObjs[uid] = newObj
+					return event, true
 				}
+				return event, false
+			})
 
-				return []ResourceEvent{event}
-			}))
+			deleteEvents := lo.FilterMap(lo.Keys(oldObjs), func(uid string, _ int) (ResourceEvent, bool) {
+				oldObj := oldObjs[uid]
+				event := ResourceEvent{
+					Kind:      oldObj.GetObjectKind().GroupVersionKind().GroupKind(),
+					OldObject: oldObj,
+				}
+				_, exists := newObjs[uid]
+				return event, !exists
+			})
+
+			events = append(events, deleteEvents...)
+
+			c.propagate(events)
 
 			c.Unlock()
 		}

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -173,11 +173,6 @@ func TestNewController(t *testing.T) {
 			if c.manager != tc.expected.manager {
 				t.Errorf("expected manager %v, got %v", tc.expected.manager, c.manager)
 			}
-			switch c.cache.(type) {
-			case *watchableCacheStore:
-			default:
-				t.Errorf("expected cache type *watchableCacheStore, got %T", c.cache)
-			}
 			if len(c.topology.policyKinds) != len(tc.expected.policyKinds) || !lo.Every(c.topology.policyKinds, tc.expected.policyKinds) {
 				t.Errorf("expected policyKinds %v, got %v", tc.expected.policyKinds, c.topology.policyKinds)
 			}
@@ -200,7 +195,7 @@ func TestControllerReconcile(t *testing.T) {
 		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test-configmap", UID: "aed148b1-285a-48ab-8839-fe99475bc6fc"}},
 	}
 	objUIDs := lo.Map(objs, func(o Object, _ int) string { return string(o.GetUID()) })
-	cache := &cacheStore{store: make(Store)}
+	cache := &CacheStore{}
 	controller := &Controller{
 		logger: testLogger,
 		cache:  cache,
@@ -209,7 +204,7 @@ func TestControllerReconcile(t *testing.T) {
 		},
 	}
 	controller.Reconcile(context.TODO(), ctrlruntimereconcile.Request{})
-	cachedObjs := lo.Keys(cache.List())
+	cachedObjs := lo.Keys(cache.List(resourceStoreId))
 	if len(cachedObjs) != 2 {
 		t.Errorf("expected 2 objects, got %d", len(cachedObjs))
 	}


### PR DESCRIPTION
Make replacing the state of the cache atomic for full lists of resources, so only one message is written to the internal channel before propagation by the controller instead of one message per resource.

This will cause the sotw reconciler to pick up and propagte one single reconciliation call for each state of the world, instead of mimicking the traditional controller-runtime approach of more or less one call per cluster event.