### PR TITLE
topology: Add method to retrieve all topology Objects

### DIFF
--- a/machinery/test_helper.go
+++ b/machinery/test_helper.go
@@ -38,6 +38,17 @@ func linksFromTargetable(topology *Topology, targetable Targetable, edges map[st
 	}
 }
 
+func linksFromAll(topology *Topology, obj Object, edges map[string][]string) {
+	if _, ok := edges[obj.GetName()]; ok {
+		return
+	}
+	children := topology.All().Children(obj)
+	edges[obj.GetName()] = lo.Map(children, func(child Object, _ int) string { return child.GetName() })
+	for _, child := range children {
+		linksFromAll(topology, child, edges)
+	}
+}
+
 const TestGroupName = "example.test"
 
 type Apple struct {

--- a/machinery/topology.go
+++ b/machinery/topology.go
@@ -142,7 +142,6 @@ type Topology struct {
 }
 
 // Targetables returns all targetable nodes in the topology.
-// The list can be filtered by providing one or more filter functions.
 func (t *Topology) Targetables() *collection[Targetable] {
 	return &collection[Targetable]{
 		topology: t,
@@ -151,7 +150,6 @@ func (t *Topology) Targetables() *collection[Targetable] {
 }
 
 // Policies returns all policies in the topology.
-// The list can be filtered by providing one or more filter functions.
 func (t *Topology) Policies() *collection[Policy] {
 	return &collection[Policy]{
 		topology: t,
@@ -160,11 +158,25 @@ func (t *Topology) Policies() *collection[Policy] {
 }
 
 // Objects returns all non-targetable, non-policy object nodes in the topology.
-// The list can be filtered by providing one or more filter functions.
 func (t *Topology) Objects() *collection[Object] {
 	return &collection[Object]{
 		topology: t,
 		items:    t.objects,
+	}
+}
+
+// All returns all object nodes in the topology.
+func (t *Topology) All() *collection[Object] {
+	allObjects := t.objects
+	for k, v := range t.targetables {
+		allObjects[k] = v
+	}
+	for k, v := range t.policies {
+		allObjects[k] = v
+	}
+	return &collection[Object]{
+		topology: t,
+		items:    allObjects,
 	}
 }
 

--- a/machinery/types.go
+++ b/machinery/types.go
@@ -18,6 +18,10 @@ type Object interface {
 	GetLocator() string
 }
 
+func MapObjectToLocatorFunc(t Object, _ int) string {
+	return t.GetLocator()
+}
+
 func LocatorFromObject(obj Object) string {
 	name := strings.TrimPrefix(namespacedName(obj.GetNamespace(), obj.GetName()), string(k8stypes.Separator))
 	return fmt.Sprintf("%s%s%s", strings.ToLower(obj.GroupVersionKind().GroupKind().String()), string(kindNameLocatorSeparator), name)


### PR DESCRIPTION
Adds an "All()" method to the topology that returns all Objects in the topology graph i.e. Objects + Targetables + Policies.

Exposing a collection like this allows API users to more easily query the paths between any two objects regardless of type e.g Policy -> Object, Targetable -> Object etc..