### PR TITLE
fix: Linking policies to other objects

### DIFF
--- a/machinery/topology.go
+++ b/machinery/topology.go
@@ -101,6 +101,7 @@ func NewTopology(options ...TopologyOptionsFunc) (*Topology, error) {
 
 	addObjectsToGraph(graph, o.Objects)
 	addTargetablesToGraph(graph, targetables)
+	addPoliciesToGraph(graph, policies)
 
 	linkables := append(o.Objects, lo.Map(targetables, AsObject[Targetable])...)
 	linkables = append(linkables, lo.Map(policies, AsObject[Policy])...)
@@ -117,8 +118,6 @@ func NewTopology(options ...TopologyOptionsFunc) (*Topology, error) {
 			}
 		}
 	}
-
-	addPoliciesToGraph(graph, policies)
 
 	var err error
 	if !o.AllowLoops && !isDAG(graph) {

--- a/machinery/topology_test.go
+++ b/machinery/topology_test.go
@@ -515,6 +515,7 @@ func TestTopologyAll(t *testing.T) {
 	objects := []*Info{
 		{Name: "info-1", Ref: "apple.example.test:apple-1"},
 		{Name: "info-2", Ref: "orange.example.test:my-namespace/orange-1"},
+		{Name: "info-3", Ref: "fruitpolicy.test:my-namespace/policy-1"},
 	}
 	apples := []*Apple{{Name: "apple-1"}}
 	oranges := []*Orange{
@@ -543,6 +544,7 @@ func TestTopologyAll(t *testing.T) {
 			LinkApplesToOranges(apples),
 			LinkInfoFrom("Apple", lo.Map(apples, AsObject[*Apple])),
 			LinkInfoFrom("Orange", lo.Map(oranges, AsObject[*Orange])),
+			LinkInfoFrom("Policy", lo.Map(policies, AsObject[Policy])),
 		),
 	)
 
@@ -553,13 +555,14 @@ func TestTopologyAll(t *testing.T) {
 	SaveToOutputDir(t, topology.ToDot(), "../tests/out", ".dot")
 
 	expectedLinks := map[string][]string{
-		"policy-1": {"apple-1"},
+		"policy-1": {"apple-1", "info-3"},
 		"policy-2": {"orange-1"},
 		"apple-1":  {"orange-1", "orange-2", "info-1"},
 		"orange-1": {"info-2"},
 		"orange-2": {},
 		"info-1":   {},
 		"info-2":   {},
+		"info-3":   {},
 	}
 
 	links := make(map[string][]string)


### PR DESCRIPTION
Fixes an issue where it wasn't possible to create a link to a policy from an object of a different type outside of linking targettables. Currently creating an edge to a policy from an object would silently fail since the policy is not in the topology at the time of creating the links.