### PR TITLE
fix: allow linking objects to policies

### DIFF
--- a/machinery/topology.go
+++ b/machinery/topology.go
@@ -101,6 +101,7 @@ func NewTopology(options ...TopologyOptionsFunc) (*Topology, error) {
 
 	addObjectsToGraph(graph, o.Objects)
 	addTargetablesToGraph(graph, targetables)
+	addPoliciesToGraph(graph, policies)
 
 	linkables := append(o.Objects, lo.Map(targetables, AsObject[Targetable])...)
 	linkables = append(linkables, lo.Map(policies, AsObject[Policy])...)
@@ -117,8 +118,6 @@ func NewTopology(options ...TopologyOptionsFunc) (*Topology, error) {
 			}
 		}
 	}
-
-	addPoliciesToGraph(graph, policies)
 
 	var err error
 	if !o.AllowLoops && !isDAG(graph) {


### PR DESCRIPTION
# Description
Since policies were always added to the graph **after** the links, it was not possible to correctly policies to any other object.

Moving the addition of policies to the graph to before the addition of links fixes this