### PR TITLE
fix: topology all can cause race

### DIFF
--- a/machinery/topology.go
+++ b/machinery/topology.go
@@ -166,7 +166,10 @@ func (t *Topology) Objects() *collection[Object] {
 
 // All returns all object nodes in the topology.
 func (t *Topology) All() *collection[Object] {
-	allObjects := t.objects
+	allObjects := map[string]Object{}
+	for k, v := range t.objects {
+		allObjects[k] = v
+	}
 	for k, v := range t.targetables {
 		allObjects[k] = v
 	}


### PR DESCRIPTION
Topology.All() was incorrectly modifying the existing topology map instead of copying it which can cause a race `fatal error: concurrent map read and map write` under normal usage.