### PR TITLE
De/restructure objects via JSON

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -217,6 +217,9 @@ func (c *Controller) Reconcile(ctx context.Context, _ ctrlruntimereconcile.Reque
 	store := Store{}
 	for _, f := range c.listFuncs {
 		for _, object := range f() {
+			if object == nil {
+				continue
+			}
 			store[string(object.GetUID())] = object
 		}
 	}


### PR DESCRIPTION
I've been having issues with using the default Kubernetes API Machinery converter to restruct/destruct objects based on types that contain embedded fields. In particular, converting objects of such kinds often result in data loss.

This is an attempt to workaround those issues by converting via JSON. Although, theoretically more expensive, I hope this can prevent at least the data loss, which is definitely the most concerning problem.