### PR TITLE
update controller-gen to v0.16.0

### DIFF
--- a/examples/kuadrant/Makefile
+++ b/examples/kuadrant/Makefile
@@ -44,7 +44,7 @@ endef
 
 CONTROLLER_GEN = $(PROJECT_PATH)/bin/controller-gen
 $(CONTROLLER_GEN):
-	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.15.0)
+	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.0)
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN)  ## Download controller-gen locally if necessary.

--- a/examples/kuadrant/config/crds/kuadrant.io_authpolicies.yaml
+++ b/examples/kuadrant/config/crds/kuadrant.io_authpolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   labels:
     gateway.networking.k8s.io/policy: inherited
   name: authpolicies.kuadrant.io
@@ -307,9 +307,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -1607,9 +1605,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -2515,9 +2511,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -3815,9 +3809,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -4716,9 +4708,7 @@ spec:
                                     This field is effectively required, but due to backwards compatibility is
                                     allowed to be empty. Instances of this type with an empty value here are
                                     almost certainly wrong.
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
@@ -6004,9 +5994,7 @@ spec:
                                     This field is effectively required, but due to backwards compatibility is
                                     allowed to be empty. Instances of this type with an empty value here are
                                     almost certainly wrong.
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
@@ -6640,11 +6628,9 @@ spec:
                       unspecified, this targetRef targets the entire resource. In the following
                       resources, SectionName is interpreted as the following:
 
-
                       * Gateway: Listener name
                       * HTTPRoute: HTTPRouteRule name
                       * Service: Port name
-
 
                       If a SectionName is specified, but does not exist on the targeted object,
                       the Policy must fail to attach, and the policy implementation should record
@@ -6729,16 +6715,8 @@ spec:
                   Represents the observations of a foo's current state.
                   Known .status.conditions.type are: "Available"
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -6779,12 +6757,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/examples/kuadrant/config/crds/kuadrant.io_dnspolicies.yaml
+++ b/examples/kuadrant/config/crds/kuadrant.io_dnspolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   labels:
     gateway.networking.k8s.io/policy: inherited
   name: dnspolicies.kuadrant.io
@@ -114,9 +114,7 @@ spec:
                         description: |-
                           defaultGeo is the country/continent/region code to use when no other can be determined for a dns target cluster.
 
-
                           The values accepted are determined by the target dns provider, please refer to the appropriate docs below.
-
 
                           Route53: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values-geo.html
                           Google: https://cloud.google.com/compute/docs/regions-zones
@@ -193,9 +191,7 @@ spec:
                         description: |-
                           defaultWeight is the record weight to use when no other can be determined for a dns target cluster.
 
-
                           The maximum value accepted is determined by the target dns provider, please refer to the appropriate docs below.
-
 
                           Route53: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy-weighted.html
                         minimum: 0
@@ -241,11 +237,9 @@ spec:
                       unspecified, this targetRef targets the entire resource. In the following
                       resources, SectionName is interpreted as the following:
 
-
                       * Gateway: Listener name
                       * HTTPRoute: HTTPRouteRule name
                       * Service: Port name
-
 
                       If a SectionName is specified, but does not exist on the targeted object,
                       the Policy must fail to attach, and the policy implementation should record
@@ -279,16 +273,8 @@ spec:
                   Represents the observations of a foo's current state.
                   Known .status.conditions.type are: "Available"
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -329,12 +315,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/examples/kuadrant/config/crds/kuadrant.io_ratelimitpolicies.yaml
+++ b/examples/kuadrant/config/crds/kuadrant.io_ratelimitpolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   labels:
     gateway.networking.k8s.io/policy: inherited
   name: ratelimitpolicies.kuadrant.io
@@ -80,9 +80,8 @@ spec:
                       description: Limit represents a complete rate limit configuration
                       properties:
                         counters:
-                          description: |-
-                            Counters defines additional rate limit counters based on context qualifiers and well known selectors
-                            TODO Document properly "Well-known selector" https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                          description: Counters defines additional rate limit counters
+                            based on context qualifiers and well known selectors
                           items:
                             description: |-
                               ContextSelector defines one item from the well known attributes
@@ -147,9 +146,8 @@ spec:
                                 - matches
                                 type: string
                               selector:
-                                description: |-
-                                  Selector defines one item from the well known selectors
-                                  TODO Document properly "Well-known selector" https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                description: Selector defines one item from the well
+                                  known selectors
                                 maxLength: 253
                                 minLength: 1
                                 type: string
@@ -181,9 +179,8 @@ spec:
                   description: Limit represents a complete rate limit configuration
                   properties:
                     counters:
-                      description: |-
-                        Counters defines additional rate limit counters based on context qualifiers and well known selectors
-                        TODO Document properly "Well-known selector" https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                      description: Counters defines additional rate limit counters
+                        based on context qualifiers and well known selectors
                       items:
                         description: |-
                           ContextSelector defines one item from the well known attributes
@@ -248,9 +245,8 @@ spec:
                             - matches
                             type: string
                           selector:
-                            description: |-
-                              Selector defines one item from the well known selectors
-                              TODO Document properly "Well-known selector" https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                            description: Selector defines one item from the well known
+                              selectors
                             maxLength: 253
                             minLength: 1
                             type: string
@@ -278,9 +274,8 @@ spec:
                       description: Limit represents a complete rate limit configuration
                       properties:
                         counters:
-                          description: |-
-                            Counters defines additional rate limit counters based on context qualifiers and well known selectors
-                            TODO Document properly "Well-known selector" https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                          description: Counters defines additional rate limit counters
+                            based on context qualifiers and well known selectors
                           items:
                             description: |-
                               ContextSelector defines one item from the well known attributes
@@ -345,9 +340,8 @@ spec:
                                 - matches
                                 type: string
                               selector:
-                                description: |-
-                                  Selector defines one item from the well known selectors
-                                  TODO Document properly "Well-known selector" https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                description: Selector defines one item from the well
+                                  known selectors
                                 maxLength: 253
                                 minLength: 1
                                 type: string
@@ -399,11 +393,9 @@ spec:
                       unspecified, this targetRef targets the entire resource. In the following
                       resources, SectionName is interpreted as the following:
 
-
                       * Gateway: Listener name
                       * HTTPRoute: HTTPRouteRule name
                       * Service: Port name
-
 
                       If a SectionName is specified, but does not exist on the targeted object,
                       the Policy must fail to attach, and the policy implementation should record
@@ -440,16 +432,8 @@ spec:
                   Represents the observations of a foo's current state.
                   Known .status.conditions.type are: "Available"
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -490,12 +474,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/examples/kuadrant/config/crds/kuadrant.io_tlspolicies.yaml
+++ b/examples/kuadrant/config/crds/kuadrant.io_tlspolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   labels:
     gateway.networking.k8s.io/policy: inherited
   name: tlspolicies.kuadrant.io
@@ -117,7 +117,6 @@ spec:
                       Algorithm is the private key algorithm of the corresponding private key
                       for this certificate.
 
-
                       If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
                       If `algorithm` is specified and `size` is not provided,
                       key size of 2048 will be used for `RSA` key algorithm and
@@ -133,7 +132,6 @@ spec:
                       The private key cryptography standards (PKCS) encoding for this
                       certificate's private key to be encoded in.
 
-
                       If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
                       and PKCS#8, respectively.
                       Defaults to `PKCS1` if not specified.
@@ -145,7 +143,6 @@ spec:
                     description: |-
                       RotationPolicy controls how private keys should be regenerated when a
                       re-issuance is being processed.
-
 
                       If set to `Never`, a private key will only be generated if one does not
                       already exist in the target `spec.secretName`. If one does exists but it
@@ -161,7 +158,6 @@ spec:
                   size:
                     description: |-
                       Size is the key bit size of the corresponding private key for this certificate.
-
 
                       If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
                       and will default to `2048` if not specified.
@@ -215,11 +211,9 @@ spec:
                       unspecified, this targetRef targets the entire resource. In the following
                       resources, SectionName is interpreted as the following:
 
-
                       * Gateway: Listener name
                       * HTTPRoute: HTTPRouteRule name
                       * Service: Port name
-
 
                       If a SectionName is specified, but does not exist on the targeted object,
                       the Policy must fail to attach, and the policy implementation should record
@@ -248,7 +242,6 @@ spec:
                     See:
                     https://tools.ietf.org/html/rfc5280#section-4.2.1.3
                     https://tools.ietf.org/html/rfc5280#section-4.2.1.12
-
 
                     Valid KeyUsage values are as follows:
                     "signing",
@@ -311,16 +304,8 @@ spec:
                   Represents the observations of a foo's current state.
                   Known .status.conditions.type are: "Available"
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -361,12 +346,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string


### PR DESCRIPTION
thanks to @KevFan for pointer

resolves some issues with the kuadrant example and v0.15.0:

```bash
make manifests                                                                                                                git:(main->origin/main|)
go: creating new go.mod: module tmp
Downloading sigs.k8s.io/controller-tools/cmd/controller-gen@v0.15.0
/Users/jmadigan/Work/policy-machinery/examples/kuadrant/bin/controller-gen crd paths="./apis/v1alpha2;./apis/v1beta3" output:crd:artifacts:config=config/crds
/Users/jmadigan/go/pkg/mod/k8s.io/api@v0.31.0/core/v1/doc.go:21:1: missing argument "" (at <input>)
/Users/jmadigan/go/pkg/mod/k8s.io/api@v0.31.0/core/v1/doc.go:21:1: missing argument "" (at <input>)
k8s.io/api/core/v1:-: unknown type "k8s.io/api/core/v1".LocalObjectReference
k8s.io/api/core/v1:-: unknown type "k8s.io/api/core/v1".LocalObjectReference
k8s.io/api/core/v1:-: unknown type "k8s.io/api/core/v1".LocalObjectReference
k8s.io/api/core/v1:-: unknown type "k8s.io/api/core/v1".LocalObjectReference
github.com/kuadrant/authorino/api/v1beta2:-: unable to locate schema for type "k8s.io/api/core/v1".LocalObjectReference
github.com/kuadrant/authorino/api/v1beta2:-: unable to locate schema for type "k8s.io/api/core/v1".LocalObjectReference
Error: not all generators ran successfully
run `controller-gen crd paths=./apis/v1alpha2;./apis/v1beta3 output:crd:artifacts:config=config/crds -w` to see all available markers, or `controller-gen crd paths=./apis/v1alpha2;./apis/v1beta3 output:crd:artifacts:config=config/crds -h` for usage
make: *** [manifests] Error 1
```