### PR TITLE
machinery/types.go: LocatorFromObject simpler signature

### DIFF
--- a/machinery/types.go
+++ b/machinery/types.go
@@ -18,11 +18,17 @@ type Object interface {
 	GetLocator() string
 }
 
+type LocatableObject interface {
+	GroupVersionKind() schema.GroupVersionKind
+	GetNamespace() string
+	GetName() string
+}
+
 func MapObjectToLocatorFunc(t Object, _ int) string {
 	return t.GetLocator()
 }
 
-func LocatorFromObject(obj Object) string {
+func LocatorFromObject(obj LocatableObject) string {
 	name := strings.TrimPrefix(namespacedName(obj.GetNamespace(), obj.GetName()), string(k8stypes.Separator))
 	return fmt.Sprintf("%s%s%s", strings.ToLower(obj.GroupVersionKind().GroupKind().String()), string(kindNameLocatorSeparator), name)
 }


### PR DESCRIPTION
### What
In package `machinery`, change signature of the method `LocatorFromObject` from 

```go
func LocatorFromObject(obj Object) string
```
to
```go
func LocatorFromObject(obj LocatableObject) string
```

`LocatableObject` object being

```go
type LocatableObject interface {
	GroupVersionKind() schema.GroupVersionKind
	GetNamespace() string
	GetName() string
}
```

### Why

Most types implementing `machinery.Object` interface end up implementing the required `GetLocator() string` as the following:
```go
type Apple struct { 
...
}

func (a *Apple) GetLocator() string { 
    return LocatorFromObject(a)       
}                                     

```
There is an implicit cyclic dependency that is not necessary at all. As it was, to implement a interface method, the method is calling another method (`LocatorFromObject`) that requires type implementing `machinery.Object`. 

### How

Relaxing the requirements for implementing `LocatorFromObject`. That method only needs three methods to be implemented by the passed parameter. Hence, it is proposed a new interface called `LocatableObject` having precisely those three methods. 

```go
type LocatableObject interface {
	GroupVersionKind() schema.GroupVersionKind
	GetNamespace() string
	GetName() string
}
```
