### PR TITLE
feat: allow additionalAttrsFn for enhancing TraceReconcileFunc

### DIFF
--- a/controller/tracing.go
+++ b/controller/tracing.go
@@ -29,9 +29,18 @@ func TracerIntoContext(ctx context.Context, tracer trace.Tracer) context.Context
 	return context.WithValue(ctx, tracerKey{}, tracer)
 }
 
+// AdditionalAttrsFn returns additional []attribute.KeyValue's derived from the reconciliation parameters to be added to
+// the span created for this reconciliation in TraceReconcileFunc.
+type AdditionalAttrsFn func(resourceEvents []ResourceEvent, topology *machinery.Topology, err error, state *sync.Map) []attribute.KeyValue
+
 // TraceReconcileFunc wraps a ReconcileFunc with tracing instrumentation.
 // It extracts the tracer from the context, starts a span with the given name,
 // and automatically records errors and carryover error context.
+//
+// additionalAttrs allows callers to enrich the span with attributes describing
+// the overall workflow context (e.g. event counts, topology metadata) without
+// modifying the reconciler function itself. For attributes specific to what the
+// reconciler does internally, set them inside fn via trace.SpanFromContext(ctx).
 //
 // Note: This function does NOT automatically inject trace IDs into the logger.
 // If you want trace-log correlation, use TraceLoggerFromContext in your reconciler:
@@ -41,7 +50,7 @@ func TracerIntoContext(ctx context.Context, tracer trace.Tracer) context.Context
 //	    logger.Info("processing") // Will have trace_id and span_id
 //	    return nil
 //	})
-func TraceReconcileFunc(spanName string, fn ReconcileFunc) ReconcileFunc {
+func TraceReconcileFunc(spanName string, fn ReconcileFunc, additionalAttrs ...AdditionalAttrsFn) ReconcileFunc {
 	return func(ctx context.Context, events []ResourceEvent, topology *machinery.Topology, errIn error, state *sync.Map) error {
 		tracer := TracerFromContext(ctx)
 
@@ -52,6 +61,11 @@ func TraceReconcileFunc(spanName string, fn ReconcileFunc) ReconcileFunc {
 		if errIn != nil {
 			span.RecordError(errIn)
 			span.SetAttributes(attribute.Bool("error.carryover", true))
+		}
+
+		// Add custom attributes before running reconciliation
+		for _, attrFn := range additionalAttrs {
+			span.SetAttributes(attrFn(events, topology, errIn, state)...)
 		}
 
 		// Execute the wrapped function


### PR DESCRIPTION
# Description
  Taken from the Kuadrant Operator, as it is better suited in this repository.
  - https://github.com/Kuadrant/kuadrant-operator/blob/5949be570a29d656d8be3021c190edc89d9e6c9f/internal/controller/state_of_the_world.go#L669-L699                                                              
                  
  - Enhances `TraceReconcileFunc` with optional `AdditionalAttrsFn` callbacks to enrich the span with additional attributes before reconciliation (e.g. for adding workflow-level span attributes rather than
  those specific to individual tasks)