### PR TITLE
Export `Controller.Propagate` method

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -271,7 +271,7 @@ func (c *Controller) delete(obj Object) {
 	c.cache.Delete(resourceStoreId, obj)
 }
 
-func (c *Controller) propagate(resourceEvents []ResourceEvent) {
+func (c *Controller) Propagate(resourceEvents []ResourceEvent) {
 	c.logger.V(1).Info("propagating new state of the world events", "events", len(resourceEvents))
 	defer c.logger.V(1).Info("finished propagating new state of the world events")
 
@@ -375,7 +375,7 @@ func (c *Controller) handleCacheEvent(snapshot watchable.Snapshot[string, Store]
 	events = append(events, deleteEvents...)
 
 	if len(events) > 0 { // this condition is actually redundant; if the snapshot has updates, there must be events
-		c.propagate(events)
+		c.Propagate(events)
 	} else {
 		c.logger.V(1).Info("state of the world has not changed")
 	}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -272,6 +272,12 @@ func (c *Controller) delete(obj Object) {
 }
 
 func (c *Controller) Propagate(resourceEvents []ResourceEvent) {
+	c.Lock()
+	defer c.Unlock()
+	c.propagateLocked(resourceEvents)
+}
+
+func (c *Controller) propagateLocked(resourceEvents []ResourceEvent) {
 	c.logger.V(1).Info("propagating new state of the world events", "events", len(resourceEvents))
 	defer c.logger.V(1).Info("finished propagating new state of the world events")
 
@@ -375,7 +381,7 @@ func (c *Controller) handleCacheEvent(snapshot watchable.Snapshot[string, Store]
 	events = append(events, deleteEvents...)
 
 	if len(events) > 0 { // this condition is actually redundant; if the snapshot has updates, there must be events
-		c.Propagate(events)
+		c.propagateLocked(events)
 	} else {
 		c.logger.V(1).Info("state of the world has not changed")
 	}


### PR DESCRIPTION
Export `Controller.Propagate` method so clients can trigger arbitrary reconciliation calls containing the latest copy of the topology built from the cache.

This is useful in cases where the client wants to handle retries on its own conditions, such as the one described in https://github.com/Kuadrant/kuadrant-operator/issues/946 for example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Event propagation is now publicly accessible for external consumers of the controller API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->