### PR TITLE
Upgrade Go to 1.26.4

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/policy-machinery/examples
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/cert-manager/cert-manager v1.16.2

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/policy-machinery/examples
 
-go 1.25.9
+go 1.26.3
 
 require (
 	github.com/cert-manager/cert-manager v1.16.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/policy-machinery
 
-go 1.25.9
+go 1.26.3
 
 require (
 	github.com/emicklei/dot v1.8.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/policy-machinery
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/emicklei/dot v1.8.0


### PR DESCRIPTION
Upgrade Go from 1.25.9 to 1.26.3.

**Changes:**
- Updated `go` directive in `go.mod` (root)
- Updated `go` directive in `examples/go.mod`
- Ran `go mod tidy` in both modules (no dependency changes)